### PR TITLE
Revert "Maliciously insert typo"

### DIFF
--- a/hello.py
+++ b/hello.py
@@ -1,13 +1,12 @@
 import sys
 
 def main(animal):
-    aminal = "aminal"
-    if aminal == "cat":
+    if animal == "cat":
         print("Meow!")
     elif animal == "dog":
         print("Woof!")
     else:
-        print("What does the " + aminal + " say?")
+        print("What does the " + animal + " say?")
 
 if __name__ == "__main__":
     main(sys.argv[1])


### PR DESCRIPTION
This reverts commit ad2578561962b14791ce480c90be6d4a86835576.

fix: revert commit "Maliciously insert typo"
The error was due to a typo in "animal" in a previous commit.